### PR TITLE
fix: override assets for cosmos

### DIFF
--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tangled3/react
 
+## 1.16.63
+
+### Patch Changes
+
+- chore:injective changes
+
 ## 1.16.62
 
 ### Patch Changes

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tangled3/react
 
+## 1.16.62
+
+### Patch Changes
+
+- chore: cosmos override
+
 ## 1.16.61
 
 ### Patch Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tangled3/react",
   "private": false,
-  "version": "1.16.61",
+  "version": "1.16.62",
   "type": "module",
   "license": "MIT",
   "main": "./src/index.ts",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tangled3/react",
   "private": false,
-  "version": "1.16.62",
+  "version": "1.16.63",
   "type": "module",
   "license": "MIT",
   "main": "./src/index.ts",

--- a/packages/react/src/actions/cosmos/getCosmosChainRegistryClient.ts
+++ b/packages/react/src/actions/cosmos/getCosmosChainRegistryClient.ts
@@ -3,6 +3,7 @@ import {
   ChainRegistryChainUtil,
   ChainRegistryFetcher,
 } from '@chain-registry/client';
+import { AssetList } from '../../types/cosmos.js';
 
 interface ChainRegistryClientOptions extends BaseChainRegistryClientOptions {
   testnet?: boolean | undefined;
@@ -89,6 +90,13 @@ export class ChainRegistryClient extends ChainRegistryFetcher {
     await Promise.allSettled(this.urls.map((url) => this.fetch(url)));
 
     return Promise.all([]);
+  }
+
+  setAssetList(customAssetList: AssetList | undefined, chainName: string) {
+    const chainAssetList = this.assetLists.find((asset) => asset.chain_name === chainName);
+    if (chainAssetList && customAssetList) {
+      chainAssetList.assets = customAssetList.assets;
+    }
   }
 }
 

--- a/packages/react/src/actions/cosmos/getCosmosToken.ts
+++ b/packages/react/src/actions/cosmos/getCosmosToken.ts
@@ -2,7 +2,6 @@ import { SigningCosmWasmClient } from '@cosmjs/cosmwasm-stargate';
 import { maxInt256 } from 'viem';
 import { RouterLCDBalancesResponse } from '../../types/cosmos.js';
 import { ChainData, ConnectionOrConfig, CosmsosChainType } from '../../types/index.js';
-import getOverridenAssets from '../../utils/getOverridenAssetsForCosmos.js';
 import { compareStrings, isCosmosNativeOrFactoryToken } from '../../utils/index.js';
 
 export const getCosmosTokenMetadata = async ({
@@ -18,13 +17,10 @@ export const getCosmosTokenMetadata = async ({
 
   const assetList = registryClient.getChainAssetList(chain.chainName).assets;
 
-  let asset = assetList.find((asset) => compareStrings(asset.base, token));
+  const asset = assetList.find((asset) => compareStrings(asset.base, token));
 
   if (!asset) {
-    asset = getOverridenAssets({ chain, token });
-    if (!asset) {
-      throw new Error('Token not found');
-    }
+    throw new Error('Token not found');
   }
   return {
     symbol: asset.symbol,

--- a/packages/react/src/store/Cosmos.ts
+++ b/packages/react/src/store/Cosmos.ts
@@ -7,6 +7,7 @@ import {
 } from '../actions/cosmos/getCosmosChainRegistryClient.js';
 import { AssetList } from '../types/cosmos.js';
 import { ChainData, CosmsosChainType } from '../types/index.js';
+import { getAssetsToOverride, overrideMap } from '../utils/getAssetsToOverride.js';
 import { fetchTestnetAssetLists } from '../utils/index.js';
 
 export type GetCosmosClient = () => {
@@ -83,6 +84,21 @@ export const createCosmosStore = (chains: ChainData[], testnet: boolean | undefi
           newAssetList = await Promise.all(
             chainRegistry.chains.map((chain) => fetchTestnetAssetLists(chain.chain_name)),
           );
+          newAssetList.forEach((assetItem) => {
+            const overrideKey = overrideMap[assetItem.chain_name];
+            if (overrideKey) {
+              const overriddenAssets = getAssetsToOverride(overrideKey);
+              assetItem.assets = assetItem.assets.concat(overriddenAssets);
+            }
+          });
+
+          // updating assetLists in chainRegistry
+          Object.keys(overrideMap).forEach((chainName) => {
+            const assetList = newAssetList.find((a) => a.chain_name === chainName);
+            if (assetList) {
+              chainRegistry.setAssetList(assetList, chainName);
+            }
+          });
         }
 
         const currentAssetList = get().assetList;

--- a/packages/react/src/store/Cosmos.ts
+++ b/packages/react/src/store/Cosmos.ts
@@ -88,7 +88,11 @@ export const createCosmosStore = (chains: ChainData[], testnet: boolean | undefi
             const overrideKey = overrideMap[assetItem.chain_name];
             if (overrideKey) {
               const overriddenAssets = getAssetsToOverride(overrideKey);
-              assetItem.assets = assetItem.assets.concat(overriddenAssets);
+              // filtering out assets that already exist in the assetList
+              const newAssets = overriddenAssets.filter(
+                (overrideAsset) => !assetItem.assets.some((existingAsset) => existingAsset.base === overrideAsset.base),
+              );
+              assetItem.assets = assetItem.assets.concat(newAssets);
             }
           });
 

--- a/packages/react/src/utils/getAssetsToOverride.ts
+++ b/packages/react/src/utils/getAssetsToOverride.ts
@@ -1,7 +1,13 @@
-import { CosmsosChainType } from '../types/index.js';
+import { Asset } from '../types/cosmos.js';
+import { ChainId } from '../types/index.js';
+
+export const overrideMap: Record<string, ChainId> = {
+  injectivetestnet: 'injective-888',
+  // more mappings here as needed
+};
 
 const specialAssetOverrides: {
-  [chainId: string]: { [token: string]: any };
+  [chainId: string]: { [token: string]: Asset };
 } = {
   'router_9600-1': {
     'ibc/B9E4FD154C92D3A23BEA029906C4C5FF2FE74CB7E3A058290B77197A263CF88B': {
@@ -148,8 +154,8 @@ const specialAssetOverrides: {
   },
 };
 
-function getOverridenAssets({ chain, token }: { chain: CosmsosChainType; token: string }) {
-  return specialAssetOverrides[chain.id]?.[token];
-}
-
-export default getOverridenAssets;
+export const getAssetsToOverride = (chainId: ChainId) => {
+  const overriddenAssets = specialAssetOverrides[chainId];
+  const moreAssets = Object.entries(overriddenAssets).map(([, value]) => value);
+  return moreAssets;
+};

--- a/packages/react/src/utils/getAssetsToOverride.ts
+++ b/packages/react/src/utils/getAssetsToOverride.ts
@@ -95,33 +95,6 @@ const specialAssetOverrides: {
       ],
       type_asset: 'sdk.coin',
     },
-    'ibc/2CD6478D5AFA173C86448E008B760934166AED04C3968874EA6E44D2ECEA236D': {
-      description: 'OSMO is the native token of the Osmosis blockchain, bridged over to the Injective testnet.',
-      denom_units: [
-        {
-          denom: 'ibc/2CD6478D5AFA173C86448E008B760934166AED04C3968874EA6E44D2ECEA236D',
-          exponent: 0,
-        },
-        {
-          denom: 'UOSMO',
-          exponent: 6,
-        },
-      ],
-      base: 'ibc/2CD6478D5AFA173C86448E008B760934166AED04C3968874EA6E44D2ECEA236D',
-      name: 'Osmosis',
-      display: 'UOSMO',
-      symbol: 'UOSMO',
-      logo_URIs: {
-        png: 'https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png',
-      },
-      coingecko_id: 'osmosis',
-      images: [
-        {
-          png: 'https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmo.png',
-        },
-      ],
-      type_asset: 'ics20',
-    },
     peggy0x87aB3B4C8661e07D6372361211B96ed4Dc36B1B5: {
       description: 'USDT is a USD-pegged stablecoin available on the Injective testnet.',
       denom_units: [


### PR DESCRIPTION
- manually changing the assetList of chainRegistry client in case we need to add tokens of our choice